### PR TITLE
[Fix] Fixes lavalink.js to not send voiceUpdate when bot leaves the voice channel

### DIFF
--- a/src/base/Node.ts
+++ b/src/base/Node.ts
@@ -74,7 +74,7 @@ export default abstract class BaseNode extends EventEmitter {
     if (packet.user_id !== this.userID) return Promise.resolve(false);
 
     this.voiceStates.set(packet.guild_id, packet.session_id);
-    return Promise.resolve(false);
+    return this._tryConnection(packet.guild_id);
   }
 
   public voiceServerUpdate(packet: VoiceServerUpdate) {
@@ -88,6 +88,7 @@ export default abstract class BaseNode extends EventEmitter {
     if (!state || !server) return false;
 
     await this.players.get(guildID).voiceUpdate(state, server);
+    this.voiceServers.delete(guildID);
     return true;
   }
 }

--- a/src/base/Node.ts
+++ b/src/base/Node.ts
@@ -74,7 +74,7 @@ export default abstract class BaseNode extends EventEmitter {
     if (packet.user_id !== this.userID) return Promise.resolve(false);
 
     this.voiceStates.set(packet.guild_id, packet.session_id);
-    return this._tryConnection(packet.guild_id);
+    return Promise.resolve(true);
   }
 
   public voiceServerUpdate(packet: VoiceServerUpdate) {

--- a/src/base/Node.ts
+++ b/src/base/Node.ts
@@ -74,7 +74,7 @@ export default abstract class BaseNode extends EventEmitter {
     if (packet.user_id !== this.userID) return Promise.resolve(false);
 
     this.voiceStates.set(packet.guild_id, packet.session_id);
-    return Promise.resolve(true);
+    return Promise.resolve(false);
   }
 
   public voiceServerUpdate(packet: VoiceServerUpdate) {


### PR DESCRIPTION
lavalink.js currently sends voiceUpdate on voice_state_update and voice_server_update but that incorrect according to Fre_d (creator of Lavalink) and Napstar which is a maintiancer of magma (whats used by Lavalink). We should only send it on voice_server_update's.