### PR TITLE
ts: Change method signature to property signature

### DIFF
--- a/src/ClusterNode.ts
+++ b/src/ClusterNode.ts
@@ -42,7 +42,5 @@ export default class ClusterNode extends BaseNode {
     return this.cluster.emit(name, ...args);
   }
 
-  public send(guildID: string, pk: object): Promise<any> {
-    return this.cluster.send(guildID, pk);
-  }
+  public send = (guildID: string, pk: object): Promise<any> => this.cluster.send(guildID, pk);
 }

--- a/src/base/Cluster.ts
+++ b/src/base/Cluster.ts
@@ -4,8 +4,8 @@ import Player from '../core/Player';
 import { VoiceStateUpdate, VoiceServerUpdate } from './Node';
 
 export default abstract class BaseCluster extends EventEmitter {
-  public abstract send(guildID: string, packet: any): any;
-  public abstract filter(node: ClusterNode, guildID: string): boolean;
+  public abstract send: (guildID: string, packet: any) => any;
+  public abstract filter: (node: ClusterNode, guildID: string) => boolean;
 
   public readonly nodes: ClusterNode[] = [];
 

--- a/src/base/Node.ts
+++ b/src/base/Node.ts
@@ -34,7 +34,7 @@ export interface BaseNodeOptions {
 }
 
 export default abstract class BaseNode extends EventEmitter {
-  public abstract send(guildID: string, packet: any): Promise<any>;
+  public abstract send: (guildID: string, packet: any) => Promise<any>;
 
   public password: string;
   public userID: string;


### PR DESCRIPTION
Fixes errors in `typescript@next`.

```ts
node_modules/lavalink/typings/src/Cluster.d.ts:9:5 - error TS2424: Class 'BaseCluster' defines instance member function 'filter', but extended class 'Cluster' defines it as instance member property.

9     filter: (node: ClusterNode, guildID: string) => boolean;
      ~~~~~~

node_modules/lavalink/typings/src/Cluster.d.ts:10:5 - error TS2424: Class 'BaseCluster' defines instance member function 'send', but extended class 'Cluster' defines it as instance member property.

10     send: (guildID: string, packet: any) => any;
       ~~~~

node_modules/lavalink/typings/src/Node.d.ts:6:5 - error TS2424: Class 'BaseNode' defines instance member function 'send', but extended class 'Node' defines it as instance member property.

6     send: (guildID: string, packet: any) => any;
      ~~~~


Found 3 errors.
```