### PR TITLE
add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+indent_style=space
+indent_size=space
+end_of_line = lf
+insert_final_newline = true


### PR DESCRIPTION
This adds an .editorconfig file which helps (for me at least) to let the IDE pickup the indentation and not use there own defaults, it is also supported by all major IDE and there is no reason to not have it