### PR TITLE
Undeprecate `setVolume` function

### DIFF
--- a/src/core/Player.ts
+++ b/src/core/Player.ts
@@ -248,6 +248,4 @@ export default class Player<T extends BaseNode = BaseNode> extends EventEmitter 
   }
 }
 
-Player.prototype.setVolume = deprecate(Player.prototype.setVolume, "Player#setVolume: use setFilters instead");
-
 Player.prototype.setEqualizer = deprecate(Player.prototype.setEqualizer, "Player#setEqualizer: use setFilters instead");


### PR DESCRIPTION
The `volume` operation is no longer deprecated.
Ref: https://github.com/freyacodes/Lavalink/commit/d5967bfce6155fb0d2ec4bc229819010323fed36