### PR TITLE
fix(node): Cache the full VoiceStateUpdate; fixes `Player.moveTo()`

### DIFF
--- a/src/base/Node.ts
+++ b/src/base/Node.ts
@@ -44,7 +44,7 @@ export default abstract class BaseNode extends EventEmitter {
   public players: PlayerStore<this> = new PlayerStore(this);
   public http?: Http;
 
-  public voiceStates: Map<string, string> = new Map();
+  public voiceStates: Map<string, VoiceStateUpdate> = new Map();
   public voiceServers: Map<string, VoiceServerUpdate> = new Map();
 
   private _expectingConnection: Set<string> = new Set();
@@ -85,7 +85,7 @@ export default abstract class BaseNode extends EventEmitter {
     if (packet.user_id !== this.userID) return Promise.resolve(false);
 
     if (packet.channel_id) {
-      this.voiceStates.set(packet.guild_id, packet.session_id);
+      this.voiceStates.set(packet.guild_id, packet);
       return this._tryConnection(packet.guild_id);
     } else {
       this.voiceServers.delete(packet.guild_id);

--- a/src/core/Player.ts
+++ b/src/core/Player.ts
@@ -138,14 +138,7 @@ export default class Player<T extends BaseNode = BaseNode> extends EventEmitter 
   }
 
   public get voiceState(): VoiceStateUpdate | undefined {
-    const session = this.node.voiceStates.get(this.guildID);
-    if (!session) return;
-
-    return {
-      guild_id: this.guildID,
-      user_id: this.node.userID,
-      session_id: session,
-    };
+    return this.node.voiceStates.get(this.guildID);
   }
 
   public get voiceServer(): VoiceServerUpdate | undefined {
@@ -228,10 +221,10 @@ export default class Player<T extends BaseNode = BaseNode> extends EventEmitter 
     this.node.players.delete(this.guildID);
   }
 
-  public voiceUpdate(sessionId: string, event: VoiceServerUpdate) {
+  public voiceUpdate(state: VoiceStateUpdate, server: VoiceServerUpdate) {
     return this.send('voiceUpdate', {
-      event,
-      sessionId,
+      event: server,
+      sessionId: state.session_id,
     });
   }
 


### PR DESCRIPTION
Currently, only the `session_id` is cached. When needed, a `VoiceStateUpdate` is reconstructed by the getter [`Player.voiceState`](https://github.com/lavalibs/lavalink.js/blob/03ceda5386a02b2614f76b5de640c63b605f1d67/src/core/Player.ts#L140-L149).
However, this "reconstructed" VSU is missing the `channel_id` property. This break [`Player.moveTo()`](https://github.com/lavalibs/lavalink.js/blob/03ceda5386a02b2614f76b5de640c63b605f1d67/src/core/Player.ts#L155-L164), because it calls [`Node.voiceStateUpdate()`](https://github.com/lavalibs/lavalink.js/blob/03ceda5386a02b2614f76b5de640c63b605f1d67/src/base/Node.ts#L84-L96) with this partial VSU, which is basically a noop without a `channel_id`.

This commit fixes this issue by caching the full `VoiceStateUpdate` (which includes the `channel_id`) in the `Node.voiceStates` Map.

This is the cleanest way I found.
* I cannot cache the `channel_id` in the `Player`, because it may not exists yet when `Node.voiceStateUpdate()` is called (and creating it at this point may be undesirable).
* Creating another `Map` just to cache the `channel_id` looks wrong.
* Passing a fake `channel_id` to `Node.voiceStateUpdate()` would works, but it's a ugly fix.

For the record, `Player.moveTo()` appears to have been broken by the commit 551792856fa110c499d87bc4a34e49d5835e2f09 which changed the behavior of `Node.voiceStateUpdate()` when the `channel_id` property is missing.